### PR TITLE
add alternative for adding heroku remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Now that you've created a super cool web app, you want to show the world (see: e
 2. `heroku login`
 3. `heroku keys:add`
   - `rm ~/.ssh/id_*` when on the office computers
-4. `git remote add heroku heroku-git-url-here`
+4. `git remote add heroku heroku-git-url-here` OR `heroku git:remote -a heroku-app-name-here`
 5. `gem 'rails_12factor'`
 6. `git push heroku master`
   - `heroku run bundle exec rake db:migrate`


### PR DESCRIPTION
Since it's a lot harder to find the Git URL for a Heroku app (e.g. https://git.heroku.com/welp-welp.git) vs. the Heroku app name (e.g. welp-welp), give the option to add the remote via the Heroku app name.
